### PR TITLE
Update track sprites in editor on path change

### DIFF
--- a/Scripts/Track.gd
+++ b/Scripts/Track.gd
@@ -19,7 +19,7 @@ func _process(_delta):
 	if Engine.is_editor_hint():
 		# Update the sprites in the editor only if the curve has changed
 		var latest_curve_points := curve.get_baked_points()
-		if not are_packed_vector2_arrays_equal(latest_curve_points, curve_points):
+		if latest_curve_points != curve_points:
 			curve_points = latest_curve_points
 			_update_sprites()
 
@@ -72,12 +72,3 @@ func _update_crossties():
 		t = t.rotated((next_position - crosstie_position).normalized().angle())
 		t.origin = crosstie_position
 		crossties.set_instance_transform_2d(i, t)
-
-# Compares two PackedVector2Array instances for equality
-func are_packed_vector2_arrays_equal(array1: PackedVector2Array, array2: PackedVector2Array) -> bool:
-	if array1.size() != array2.size():
-		return false
-	for i in range(array1.size()):
-		if array1[i] != array2[i]:
-			return false
-	return true

--- a/Scripts/Track.gd
+++ b/Scripts/Track.gd
@@ -9,9 +9,19 @@ signal wheel_at_tail
 @export var crosstie_distance = 10
 @onready var _crosstie_mesh_instance = $Crosstie
 @onready var _crosstie_multimesh = $MultiMeshInstance2D
+@onready var curve_points = []
 
 func _ready():
+	curve_points = curve.get_baked_points()
 	_update_sprites()
+
+func _process(_delta):
+	if Engine.is_editor_hint():
+		# Update the sprites in the editor only if the curve has changed
+		var latest_curve_points := curve.get_baked_points()
+		if not are_packed_vector2_arrays_equal(latest_curve_points, curve_points):
+			curve_points = latest_curve_points
+			_update_sprites()
 
 # Connect the "from_side" of this track to the "to_side" of the other track
 #
@@ -42,7 +52,7 @@ func on_wheel_at_tail(wheel, extra, is_forward):
 	wheel_at_tail.emit(wheel, extra, is_forward)
 
 func _update_sprites():
-	$Line2D.points = curve.get_baked_points()
+	$Line2D.points = curve_points
 	_update_crossties()
 	$HeadPoint.progress_ratio = 0
 	$TailPoint.progress_ratio = 1
@@ -57,8 +67,17 @@ func _update_crossties():
 	
 	for i in range(crosstie_count):
 		var t = Transform2D()
-		var crosstie_position = curve.sample_baked((i * crosstie_distance) + crosstie_distance/2)
+		var crosstie_position = curve.sample_baked((i * crosstie_distance) + crosstie_distance / 2.0)
 		var next_position = curve.sample_baked((i + 1) * crosstie_distance)
 		t = t.rotated((next_position - crosstie_position).normalized().angle())
 		t.origin = crosstie_position
 		crossties.set_instance_transform_2d(i, t)
+
+# Compares two PackedVector2Array instances for equality
+func are_packed_vector2_arrays_equal(array1: PackedVector2Array, array2: PackedVector2Array) -> bool:
+	if array1.size() != array2.size():
+		return false
+	for i in range(array1.size()):
+		if array1[i] != array2[i]:
+			return false
+	return true


### PR DESCRIPTION
Hi, really love the project. Thanks for open-sourcing it!

I tried to solve this issue called out in the readme:

> Tracks are marked as tool in their scripts, so they can render the rail and crosstie sprites along the path in the editor. However, this only happens once when the scene is loaded in the editor, so to see any changes you have to close and re-open the scene. (I'd like to fix this but am not sure how to have the path emit any sort of signal when it is changed.)

My solution stores and compares the curve points against the latest points to see if there's been a change in the path. It uses `Engine.is_editor_hint` to only run in the editor.

I'm new to Godot, so let me know if anything looks off!